### PR TITLE
PR to use specified file instead of jamf.log

### DIFF
--- a/CasperSplash.xcodeproj/project.pbxproj
+++ b/CasperSplash.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		08EC78AA1DE7210E007960A4 /* CasperSplashBackgroundController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EC78A91DE7210E007960A4 /* CasperSplashBackgroundController.swift */; };
 		08EC78AC1DE72326007960A4 /* CasperSplashMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EC78AB1DE72326007960A4 /* CasperSplashMainViewController.swift */; };
 		08EC78AE1DE72EB0007960A4 /* SoftwareArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EC78AD1DE72EB0007960A4 /* SoftwareArray.swift */; };
+		1ADE344D1E64C0210027B18E /* TrackProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ADE344C1E64C0210027B18E /* TrackProgress.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +95,7 @@
 		08EC78A91DE7210E007960A4 /* CasperSplashBackgroundController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CasperSplashBackgroundController.swift; sourceTree = "<group>"; };
 		08EC78AB1DE72326007960A4 /* CasperSplashMainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CasperSplashMainViewController.swift; sourceTree = "<group>"; };
 		08EC78AD1DE72EB0007960A4 /* SoftwareArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoftwareArray.swift; sourceTree = "<group>"; };
+		1ADE344C1E64C0210027B18E /* TrackProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackProgress.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +152,7 @@
 				08EC78A91DE7210E007960A4 /* CasperSplashBackgroundController.swift */,
 				086F87B61D5391FD002AA791 /* CasperSplashController.swift */,
 				08EC78AB1DE72326007960A4 /* CasperSplashMainViewController.swift */,
+				1ADE344C1E64C0210027B18E /* TrackProgress.swift */,
 				089D29221D50D12200E58C6D /* Assets.xcassets */,
 				089D29241D50D12200E58C6D /* MainMenu.xib */,
 				089D29271D50D12200E58C6D /* Info.plist */,
@@ -267,7 +270,7 @@
 				TargetAttributes = {
 					089D291C1D50D12200E58C6D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = EM3ER8T33A;
+						DevelopmentTeam = AAPZK3CB24;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -347,6 +350,7 @@
 				08AC4F7D1D5222BD00CAB019 /* Preferences.swift in Sources */,
 				086F87BB1D5397AE002AA791 /* CasperSplashWebView.swift in Sources */,
 				08EC78AC1DE72326007960A4 /* CasperSplashMainViewController.swift in Sources */,
+				1ADE344D1E64C0210027B18E /* TrackProgress.swift in Sources */,
 				086F87B21D536F2B002AA791 /* Script.swift in Sources */,
 				08DAA4951D54D5430027E650 /* SoftwareStatusValueTransformer.swift in Sources */,
 				089D294D1D50F04900E58C6D /* Regexes.swift in Sources */,
@@ -488,7 +492,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = EM3ER8T33A;
+				DEVELOPMENT_TEAM = AAPZK3CB24;
 				INFOPLIST_FILE = CasperSplash/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
@@ -504,7 +508,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = EM3ER8T33A;
+				DEVELOPMENT_TEAM = AAPZK3CB24;
 				INFOPLIST_FILE = CasperSplash/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.fti.CasperSplash;

--- a/CasperSplash.xcodeproj/project.pbxproj
+++ b/CasperSplash.xcodeproj/project.pbxproj
@@ -270,7 +270,6 @@
 				TargetAttributes = {
 					089D291C1D50D12200E58C6D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = AAPZK3CB24;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -492,7 +491,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AAPZK3CB24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CasperSplash/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
@@ -508,7 +507,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AAPZK3CB24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CasperSplash/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.fti.CasperSplash;

--- a/CasperSplash.xcodeproj/xcshareddata/xcschemes/CasperSplash.xcscheme
+++ b/CasperSplash.xcodeproj/xcshareddata/xcschemes/CasperSplash.xcscheme
@@ -63,7 +63,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/CasperSplash.xcodeproj/xcshareddata/xcschemes/CasperSplash.xcscheme
+++ b/CasperSplash.xcodeproj/xcshareddata/xcschemes/CasperSplash.xcscheme
@@ -82,6 +82,16 @@
             ReferencedContainer = "container:CasperSplash.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-file"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/casperpre.txt"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/CasperSplash/AppDelegate.swift
+++ b/CasperSplash/AppDelegate.swift
@@ -34,8 +34,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, StreamDelegate {
         
         // Create background controller
         #if !DEBUG
-            // casperSplashBackgroundController = storyboard.instantiateController(withIdentifier: "backgroundWindow") as! CasperSplashBackgroundController
-            //casperSplashBackgroundController.showWindow(self)
+             casperSplashBackgroundController = storyboard.instantiateController(withIdentifier: "backgroundWindow") as! CasperSplashBackgroundController
+            casperSplashBackgroundController.showWindow(self)
         #endif
 
 

--- a/CasperSplash/AppDelegate.swift
+++ b/CasperSplash/AppDelegate.swift
@@ -34,8 +34,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, StreamDelegate {
         
         // Create background controller
         #if !DEBUG
-        casperSplashBackgroundController = storyboard.instantiateController(withIdentifier: "backgroundWindow") as! CasperSplashBackgroundController
-        casperSplashBackgroundController.showWindow(self)
+            // casperSplashBackgroundController = storyboard.instantiateController(withIdentifier: "backgroundWindow") as! CasperSplashBackgroundController
+            //casperSplashBackgroundController.showWindow(self)
         #endif
 
 

--- a/CasperSplash/CasperSplashMainViewController.swift
+++ b/CasperSplash/CasperSplashMainViewController.swift
@@ -8,10 +8,12 @@
 
 import Cocoa
 
+private var commandContext = 1
+
 class CasperSplashMainViewController: NSViewController, NSTableViewDataSource {
 
-//    @IBOutlet var theWindow: NSWindow!
-//    @IBOutlet weak var theWindowView: NSView!
+    //    @IBOutlet var theWindow: NSWindow!
+    //    @IBOutlet weak var theWindowView: NSView!
     @IBOutlet var webView: CasperSplashWebView!
     @IBOutlet var softwareTableView: NSTableView!
     @IBOutlet weak var indeterminateProgressIndicator: NSProgressIndicator!
@@ -19,117 +21,152 @@ class CasperSplashMainViewController: NSViewController, NSTableViewDataSource {
     @IBOutlet var softwareArrayController: NSArrayController!
     @IBOutlet weak var statusLabel: NSTextField!
     @IBOutlet weak var installingLabel: NSTextField!
-//    
+    //
     @IBOutlet var mainView: NSView!
     @IBOutlet weak var statusView: NSView!
-    
+
     var mainWindowController: CasperSplashController!
+
+    var tracker: TrackProgress?
 
     dynamic var softwareArray = SoftwareArray.sharedInstance.array
     let predicate = NSPredicate.init(format: "displayToUser = true")
-    
+
     override func viewDidAppear() {
         super.viewDidAppear()
         // Do view setup here.
-    
+
         self.mainView.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
         self.mainView.layer?.cornerRadius = 10
         self.mainView.layer?.shadowOpacity = 0.5
         self.mainView.layer?.shadowRadius = 2
         self.mainView.layer?.borderWidth = 0.2
-        
-        
+
+
         mainWindowController = (self.view.window?.windowController)! as! CasperSplashController
         checkSoftwareStatus()
-        
+
         //SoftwareArray.sharedInstance.addObserver(self, forKeyPath: "array", options: .new, context: nil)
-        
-    // Setup Web View
+
+        // Setup Web View
         self.webView.layer?.borderWidth = 1.0
         self.webView.layer?.borderColor = NSColor.lightGray.cgColor
         self.webView.layer?.isOpaque = true
-        
+
         if let indexHtmlPath = Preferences.sharedInstance.htmlAbsolutePath {
             webView.mainFrame.load(URLRequest(url: URL(fileURLWithPath: indexHtmlPath)))
         }
-    
-    SetupInstalling()
-        
+
+        SetupInstalling()
+
         //Preferences.sharedInstance.logFileHandle = FileHandle(forReadingAtPath: Preferences.sharedInstance.jamfLog)
         Preferences.sharedInstance.getPreferencesApplications(&softwareArray)
-        
+
         //let appDelegate = NSApp.delegate as! AppDelegate
-    Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(readTimer), userInfo: nil, repeats: true)
-    
-}
 
-@IBAction func pressedContinueButton(_ sender: AnyObject) {
-    
-    let prefs2 = Preferences.sharedInstance.postInstallScript
-    prefs2?.execute({ (isSuccessful) in
-        if !isSuccessful {
-            NSLog("Couldn't execute postInstall Script")
-        }
-        NSApplication.shared().terminate(self)
-    })
-    
-}
-
-func SetupInstalling() {
-    indeterminateProgressIndicator.startAnimation(self)
-    indeterminateProgressIndicator.isHidden = false
-    
-    installingLabel.stringValue = "Installing…"
-    
-    statusLabel.stringValue = ""
-    continueButton?.isEnabled = false
-}
-
-func errorWhileInstalling(_failedSoftwareArray: [Software]) {
-    indeterminateProgressIndicator.isHidden = true
-    installingLabel.stringValue = ""
-    continueButton?.isEnabled = true
-    statusLabel.textColor = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
-    
-    if _failedSoftwareArray.count == 1 {
-        if let failedDisplayName = _failedSoftwareArray[0].displayName {
-            statusLabel.stringValue = "\(failedDisplayName) failed to install. Support has been notified."
+        // set a timer to poll the jamf.log or not
+        if !CommandLine.arguments.contains("-file") {
+            Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(readTimer), userInfo: nil, repeats: true)
         } else {
-            statusLabel.stringValue = "An application failed to install. Support has been notified."
-        }
-        
-    } else {
-        statusLabel.stringValue = "Some applications failed to install. Support has been notified."
-    }
-    
-}
+            // find the file path
 
-func doneInstallingCriticalSoftware() {
-    continueButton?.isEnabled = true
-}
-func doneInstalling() {
-    indeterminateProgressIndicator.isHidden = true
-    installingLabel.stringValue = ""
-    statusLabel.textColor = #colorLiteral(red: 0.2818343937, green: 0.5693024397, blue: 0.1281824261, alpha: 1)
-    statusLabel.stringValue = "All applications were installed. Please click continue."
-}
+            var path = ""
+
+            for arg in 0...(CommandLine.arguments.count - 1) {
+                if CommandLine.arguments[arg] == "-file" {
+                    path = CommandLine.arguments[arg+1]
+                    continue
+                }
+            }
+            tracker = TrackProgress(submittedPath: path)
+            tracker?.addObserver(self, forKeyPath: "command", options: .new, context: &commandContext)
+            tracker?.run()
+        }
+
+    }
+
+    @IBAction func pressedContinueButton(_ sender: AnyObject) {
+
+        let prefs2 = Preferences.sharedInstance.postInstallScript
+        prefs2?.execute({ (isSuccessful) in
+            if !isSuccessful {
+                NSLog("Couldn't execute postInstall Script")
+            }
+            NSApplication.shared().terminate(self)
+        })
+
+    }
+
+    func SetupInstalling() {
+        indeterminateProgressIndicator.startAnimation(self)
+        indeterminateProgressIndicator.isHidden = false
+
+        installingLabel.stringValue = "Installing…"
+
+        statusLabel.stringValue = ""
+        continueButton?.isEnabled = false
+    }
+
+    // watch for updates from the log file
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        print(keyPath)
+        print(change)
+        if let newValue = change?[.newKey] {
+            if let software = getSoftwareFromRegex(newValue as! String) {
+                DispatchQueue.main.async {
+                    modifySoftwareArray(fromSoftware: software, softwareArray: &self.softwareArray)
+                    self.checkSoftwareStatus()
+                }
+            }
+        }
+    }
+
+    func errorWhileInstalling(_failedSoftwareArray: [Software]) {
+        indeterminateProgressIndicator.isHidden = true
+        installingLabel.stringValue = ""
+        continueButton?.isEnabled = true
+        statusLabel.textColor = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
+
+        if _failedSoftwareArray.count == 1 {
+            if let failedDisplayName = _failedSoftwareArray[0].displayName {
+                statusLabel.stringValue = "\(failedDisplayName) failed to install. Support has been notified."
+            } else {
+                statusLabel.stringValue = "An application failed to install. Support has been notified."
+            }
+
+        } else {
+            statusLabel.stringValue = "Some applications failed to install. Support has been notified."
+        }
+
+    }
+
+    func doneInstallingCriticalSoftware() {
+        continueButton?.isEnabled = true
+    }
+    func doneInstalling() {
+        indeterminateProgressIndicator.isHidden = true
+        installingLabel.stringValue = ""
+        statusLabel.textColor = #colorLiteral(red: 0.2818343937, green: 0.5693024397, blue: 0.1281824261, alpha: 1)
+        statusLabel.stringValue = "All applications were installed. Please click continue."
+    }
 
 
     func failedSoftwareArray(_ _softwareArray: [Software]) -> [Software] {
         return _softwareArray.filter({ $0.status == .failed })
     }
-    
+
     func canContinue(_ _softwareArray: [Software]) -> Bool {
         let criticalSoftwareArray = _softwareArray.filter({ $0.canContinue == false })
         return criticalSoftwareArray.filter({ $0.status == .success }).count == criticalSoftwareArray.count
     }
-    
+
     func allInstalled(_ _softwareArray: [Software]) -> Bool {
         let displayedSoftwareArray = _softwareArray.filter({ $0.displayToUser == true })
         return displayedSoftwareArray.filter({ $0.status == .success }).count == displayedSoftwareArray.count
     }
-    
-    
+
+
     func checkSoftwareStatus() {
         if failedSoftwareArray(softwareArray).count > 0 {
             errorWhileInstalling(_failedSoftwareArray: failedSoftwareArray(softwareArray))
@@ -138,16 +175,16 @@ func doneInstalling() {
         } else {
             SetupInstalling()
         }
-        
+
         if allInstalled(softwareArray) {
             doneInstalling()
         }
     }
-    
-    
-    
+
+
+
     func readTimer() -> Void {
-        
+
         DispatchQueue.global(qos: .background).async {
             if let logFileHandle = Preferences.sharedInstance.logFileHandle {
                 if let lines = readLinesFromFile(logFileHandle) {
@@ -165,6 +202,6 @@ func doneInstalling() {
             }
         }
     }
-
-
+    
+    
 }

--- a/CasperSplash/TrackProgress.swift
+++ b/CasperSplash/TrackProgress.swift
@@ -1,0 +1,93 @@
+//
+//  TrackProgress.swift
+//  CasperPre
+//
+//  Created by Joel Rennich on 2/16/17.
+//  Copyright © 2017 Trusource Labs. All rights reserved.
+//
+
+import Foundation
+
+enum StatusState {
+    case start
+    case done
+}
+
+class TrackProgress: NSObject {
+
+    // set up some defaults
+
+    var path: String
+    dynamic var statusText: String
+    dynamic var command: String
+    var status: StatusState
+    let task = Process()
+
+    let fm = FileManager()
+
+    // init
+
+    init(submittedPath: String) {
+        path = submittedPath
+        statusText = "Starting configuration"
+        command = ""
+        status = .start
+        task.launchPath = "/usr/bin/tail"
+        task.arguments = ["-f", submittedPath]
+
+    }
+
+    // watch for updates and post them
+
+    func run() {
+
+        // check to make sure the file exists
+
+        if !fm.fileExists(atPath: path) {
+            // need to make the file
+            fm.createFile(atPath: path, contents: nil, attributes: nil)
+        }
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+
+        let outputHandle = pipe.fileHandleForReading
+        outputHandle.waitForDataInBackgroundAndNotify()
+
+        var dataAvailable : NSObjectProtocol!
+        dataAvailable = NotificationCenter.default.addObserver(forName: NSNotification.Name.NSFileHandleDataAvailable,
+                                                               object: outputHandle, queue: nil) {  notification -> Void in
+                                                                let data = pipe.fileHandleForReading.availableData
+                                                                if data.count > 0 {
+                                                                    if let str = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
+                                                                        print("Task sent some data: \(str)")
+                                                                        self.processCommands(commands: str as String)
+                                                                    }
+                                                                    outputHandle.waitForDataInBackgroundAndNotify()
+                                                                } else {
+                                                                    NotificationCenter.default.removeObserver(dataAvailable)
+                                                                }
+        }
+
+        var dataReady : NSObjectProtocol!
+        dataReady = NotificationCenter.default.addObserver(forName: Process.didTerminateNotification,
+                                                           object: pipe.fileHandleForReading, queue: nil) { notification -> Void in
+                                                            print("Task terminated!")
+                                                            NotificationCenter.default.removeObserver(dataReady)
+        }
+
+        task.launch()
+
+        statusText = "Reticulating splines..."
+
+    }
+
+    func processCommands(commands: String) {
+        let allCommands = commands.components(separatedBy: "\n")
+        print(allCommands)
+        for line in allCommands {
+            print("Updating line")
+            command = line
+        }
+    }
+}


### PR DESCRIPTION
An example of watching a text file for changes instead of constantly polling the jamf.log file.

Launch with "-file /path/to/file" to override the existing behavior. Otherwise the line items are parsed the same.